### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/code/src/Attendee/Attendee.cs
+++ b/code/src/Attendee/Attendee.cs
@@ -9,7 +9,15 @@ namespace Attendees
     {
         public void WriteToDirectory(ZipArchiveEntry entry, string destDirectory)
         {
-            string destFileName = Path.Combine(destDirectory, entry.FullName);
+            // Resolve the full destination file path
+            string destFileName = Path.GetFullPath(Path.Combine(destDirectory, entry.FullName));
+            // Resolve the full destination directory path, ensure it ends with separator
+            string fullDestDirPath = Path.GetFullPath(destDirectory + Path.DirectorySeparatorChar);
+            // Validate the destination file path is within the destination directory
+            if (!destFileName.StartsWith(fullDestDirPath))
+            {
+                throw new InvalidOperationException("Entry is outside the target dir: " + destFileName);
+            }
             entry.ExtractToFile(destFileName);
         }
         


### PR DESCRIPTION
Potential fix for [https://github.com/securebeats/skills-secure-repository-supply-chain/security/code-scanning/1](https://github.com/securebeats/skills-secure-repository-supply-chain/security/code-scanning/1)

To fix this vulnerability, the code should resolve the full, absolute path of the intended destination file using `Path.GetFullPath` after combining the destination folder and entry name. Then, determine the absolute path of the destination directory (ensuring it ends with a path separator). Finally, check that the destination file's full path starts with the absolute destination directory path (case-sensitive comparison), and throw an exception if not. This ensures that no archive entry can escape the destination directory through directory traversal or similar path manipulation.

The changes are restricted to the `WriteToDirectory` method in `code/src/Attendee/Attendee.cs`. No new methods need to be written; only additional lines added to apply the appropriate validation before extracting the file.

Steps:
1. Replace the naive path combination with one validated by `Path.GetFullPath`.
2. Get the full path of the destination directory with a separator.
3. Check if the resulting file path starts with the full destination path, abort otherwise.
4. Only extract if the validation passes.

No new external dependencies are required, only standard .NET libraries already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
